### PR TITLE
feat: add map_activations_fn param in ConceptMatcher

### DIFF
--- a/linear_relational/lib/extract_token_activations.py
+++ b/linear_relational/lib/extract_token_activations.py
@@ -11,6 +11,8 @@ from .torch_utils import untuple_tensor
 from .TraceLayerDict import TraceLayerDict
 from .util import batchify, tuplify
 
+TokenLayerActivationsList = list[OrderedDict[str, list[torch.Tensor]]]
+
 
 def extract_token_activations(
     model: nn.Module,
@@ -22,12 +24,12 @@ def extract_token_activations(
     move_results_to_cpu: bool = True,
     batch_size: int = 32,
     show_progress: bool = False,
-) -> list[OrderedDict[str, list[torch.Tensor]]]:
+) -> TokenLayerActivationsList:
     if len(texts) != len(token_indices):
         raise ValueError(
             f"Expected {len(texts)} texts to match {len(token_indices)} subject token indices"
         )
-    results: list[OrderedDict[str, list[torch.Tensor]]] = []
+    results: TokenLayerActivationsList = []
     for batch in batchify(
         # need to turn the zip into a list or mypy complains
         list(zip(texts, token_indices)),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-transformers = "^4.35.2"
+transformers = "<4.42.0"
 tqdm = ">=4.0.0"
 dataclasses-json = "^0.6.2"
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -43,3 +43,7 @@ def quick_concept(
         vector=concept_vec,
         layer=layer,
     )
+
+
+def normalize(vec: torch.Tensor) -> torch.Tensor:
+    return vec / vec.norm()

--- a/tests/test_ConceptMatcher.py
+++ b/tests/test_ConceptMatcher.py
@@ -1,8 +1,13 @@
+from collections import OrderedDict
+
+import pytest
 import torch
 from transformers import GPT2LMHeadModel, GPT2TokenizerFast
 
 from linear_relational.Concept import Concept
 from linear_relational.ConceptMatcher import ConceptMatcher, ConceptMatchQuery
+from linear_relational.lib.extract_token_activations import TokenLayerActivationsList
+from tests.helpers import normalize
 
 
 def test_ConceptMatcher_query(
@@ -44,3 +49,54 @@ def test_ConceptMatcher_query_bulk(
     assert len(results) == 2
     for result in results:
         assert concept.name in result.concept_results
+
+
+def test_ConceptMatcher_query_bulk_with_map_activations_fn(
+    model: GPT2LMHeadModel, tokenizer: GPT2TokenizerFast
+) -> None:
+    concept_vec = normalize(torch.randn(768))
+    concept1 = Concept(
+        object="test_object1",
+        relation="test_relation",
+        layer=10,
+        vector=concept_vec,
+    )
+    concept2 = Concept(
+        object="test_object2",
+        relation="test_relation",
+        layer=10,
+        vector=-1 * concept_vec,
+    )
+
+    def map_activations(
+        token_layer_acts: TokenLayerActivationsList,
+    ) -> TokenLayerActivationsList:
+        mapped_token_layer_acts: TokenLayerActivationsList = []
+        for token_layer_act in token_layer_acts:
+            mapped_token_layer_act = OrderedDict()
+            for layer, acts in token_layer_act.items():
+                mapped_token_layer_act[layer] = [concept_vec for act in acts]
+            mapped_token_layer_acts.append(mapped_token_layer_act)
+        return mapped_token_layer_acts
+
+    conceptifier = ConceptMatcher(
+        model,
+        tokenizer,
+        [concept1, concept2],
+        layer_matcher="transformer.h.{num}",
+        map_activations_fn=map_activations,
+    )
+    results = conceptifier.query_bulk(
+        [
+            ConceptMatchQuery("This is a test", "test"),
+            ConceptMatchQuery("This is another test", "test"),
+        ]
+    )
+    assert len(results) == 2
+    for result in results:
+        assert result.concept_results[
+            "test_relation: test_object1"
+        ].score == pytest.approx(1.0)
+        assert result.concept_results[
+            "test_relation: test_object2"
+        ].score == pytest.approx(-1.0)


### PR DESCRIPTION
This PR adds an optional param `map_activations_fn` which can be used to modify the extracted activations in ConceptMatcher to allow things like SAEs.