### PR TITLE
fix: fix cache behavior for gemma2 and warn if caching breaks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,10 @@
 import pytest
-from transformers import GPT2LMHeadModel, GPT2TokenizerFast, LlamaTokenizer
+from transformers import (
+    GPT2LMHeadModel,
+    GPT2TokenizerFast,
+    LlamaTokenizer,
+)
+from transformers.models.gemma2.modeling_gemma2 import Gemma2Config, Gemma2ForCausalLM
 
 # loading in advance so it won't reload on every test
 # just need to make sure not to edit these models in tests...
@@ -11,6 +16,17 @@ _vicuna_tokenizer = LlamaTokenizer.from_pretrained("lmsys/vicuna-7b-v1.3", legac
 @pytest.fixture
 def model() -> GPT2LMHeadModel:
     return _model
+
+
+@pytest.fixture
+def empty_gemma2_model() -> Gemma2ForCausalLM:
+    config = Gemma2Config(
+        num_hidden_layers=3,
+        hidden_size=1024,
+        intermediate_size=2752,
+        vocab_size=_tokenizer.vocab_size,
+    )
+    return Gemma2ForCausalLM(config).eval()
 
 
 @pytest.fixture

--- a/tests/training/test_train_lre.py
+++ b/tests/training/test_train_lre.py
@@ -1,5 +1,5 @@
 import torch
-from transformers import GPT2LMHeadModel, GPT2TokenizerFast
+from transformers import GPT2LMHeadModel, GPT2TokenizerFast, PreTrainedModel
 
 from linear_relational.lib.extract_token_activations import (
     extract_final_token_activations,
@@ -91,4 +91,53 @@ def test_train_lre_on_single_prompt_perfectly_replicates_object(
         texts=[prompt.text],
         layers=["transformer.h.9"],
     )[0]["transformer.h.9"]
+    assert torch.allclose(lre(subj_act), obj_act, atol=1e-4)
+
+
+def test_train_lre_on_single_prompt_with_gemma2_perfectly_replicates_object(
+    empty_gemma2_model: PreTrainedModel, tokenizer: GPT2TokenizerFast
+) -> None:
+    fsl_prefixes = "\n".join(
+        [
+            "Berlin is located in the country of Germany",
+            "Toronto is located in the country of Canada",
+            "Lagos is located in the country of Nigeria",
+        ]
+    )
+    prompt = create_prompt(
+        text=f"{fsl_prefixes}\nTokyo is located in the country of",
+        answer="Japan",
+        subject="Tokyo",
+    )
+    prompts = [prompt]
+    lre = train_lre(
+        model=empty_gemma2_model,
+        tokenizer=tokenizer,
+        layer_matcher="model.layers.{num}",
+        relation="city in country",
+        subject_layer=1,
+        object_layer=2,
+        prompts=prompts,
+        object_aggregation="mean",
+    )
+
+    subj_index = (
+        find_token_range(tokenizer, tokenizer.encode(prompt.text), prompt.subject)[-1]
+        - 1
+    )
+    subj_act = extract_token_activations(
+        model=empty_gemma2_model,
+        tokenizer=tokenizer,
+        texts=[prompt.text],
+        layers=["model.layers.1"],
+        token_indices=[subj_index],
+    )[0]["model.layers.1"][0]
+    obj_act = extract_final_token_activations(
+        model=empty_gemma2_model,
+        tokenizer=tokenizer,
+        texts=[prompt.text],
+        layers=["model.layers.2"],
+    )[0]["model.layers.2"]
+    print(lre(subj_act))
+    print(obj_act)
     assert torch.allclose(lre(subj_act), obj_act, atol=1e-4)


### PR DESCRIPTION
Gemma2 seems to ignore normal huggingface cache settings, and requires custom params to provided: https://github.com/huggingface/transformers/issues/31981. This PR adds those params for gemma2, and updates the LRE code to fallback to ignoring caching entirely if caching breaks (with a warning message).