### PR TITLE
fix: bug with gemma cache on non-fp32

### DIFF
--- a/linear_relational/lib/torch_utils.py
+++ b/linear_relational/lib/torch_utils.py
@@ -18,6 +18,13 @@ def get_module(model: nn.Module, name: str) -> nn.Module:
     raise LookupError(name)
 
 
+def get_dtype(model: nn.Module) -> torch.dtype:
+    """
+    Returns the dtype of the model.
+    """
+    return next(model.parameters()).dtype
+
+
 def get_device(model: nn.Module) -> torch.device:
     """
     Returns the device on which the model is running.

--- a/linear_relational/training/train_lre.py
+++ b/linear_relational/training/train_lre.py
@@ -15,7 +15,11 @@ from linear_relational.lib.token_utils import (
     find_final_word_token_index,
     find_prompt_answer_data,
 )
-from linear_relational.lib.torch_utils import get_device, untuple_tensor
+from linear_relational.lib.torch_utils import (
+    get_device,
+    get_dtype,
+    untuple_tensor,
+)
 from linear_relational.lib.TraceLayer import TraceLayer
 from linear_relational.lib.TraceLayerDict import TraceLayerDict
 from linear_relational.Lre import Lre
@@ -112,7 +116,12 @@ def order_1_approx(
         hasattr(model, "config")
         and getattr(model.config, "cache_implementation", None) == "hybrid"
     ):
-        cache = HybridCache(model.config, input_ids.shape[0], input_ids.shape[1] + 1)
+        cache = HybridCache(
+            model.config,
+            input_ids.shape[0],
+            input_ids.shape[1] + 1,
+            dtype=get_dtype(model),
+        )
         cache_position = torch.arange(input_ids.shape[1], device=device)
         precache_extra_params["past_key_values"] = cache
         precache_extra_params["cache_position"] = cache_position[:subject_index]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,8 +22,8 @@ def model() -> GPT2LMHeadModel:
 def empty_gemma2_model() -> Gemma2ForCausalLM:
     config = Gemma2Config(
         num_hidden_layers=3,
-        hidden_size=1024,
-        intermediate_size=2752,
+        hidden_size=64,
+        intermediate_size=128,
         vocab_size=_tokenizer.vocab_size,
     )
     return Gemma2ForCausalLM(config).eval()


### PR DESCRIPTION
Currently, gemma2 throws an error when using a dtype other than fp32 with caching. This PR sets the cache dtype to match the model dtype.